### PR TITLE
Modifying the 'newTemplate' func

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func newTemplate(path string, fileInfo os.FileInfo, _ error) error {
 	 * relativPath := takeRelativeTo(path, "templates") returns "/html/templates/components/footer.html" .
 	 */
 	takeRelativeTo := func(givenpath string, afterDir string) string {
-	    if strings.Contains(givenpath, afterDir+"/") { 
+	    if strings.Contains(givenpath, afterDir+string(filepath.Separator)) { 
 	        wantedpart := strings.SplitAfter(givenpath, afterDir)[1:]
 	        return filepath.Join(wantedpart...)
 	    }


### PR DESCRIPTION
Issues encountered :

1. The Walk function was passing an absolute path to newTemplate, which would be appended to 'template' by the call to filepath.Join("template", path).
    The result of that would become: "<$absolute>/templates/<$absolute>/teplates/index.html". This would result into an error: no such file or directory.
    Solution: Instead of passing 'path' to the filepath.Join , we need to pass only the part of path that is relative to 'templates'. 
                   This is the purpose of the 'takeRelativeTo' function. 

2. As Walk function walks through the path, at some point it returns a directory, which we can not pass to our 'templateBox.String()' function for creating a 
    template string as that returned an error: ... is a directory. We only need to use files into that function. 
   Solution: checking so that whenever Walk returns a directory, we skip our logic for creating templates and parsing content to them.